### PR TITLE
Ensure item exists before deletion.

### DIFF
--- a/client/spawners/itemspawner.lua
+++ b/client/spawners/itemspawner.lua
@@ -284,15 +284,17 @@ Citizen.CreateThread(function()
 
 		-- Distance
 		for i, pickupInfo in pairs(localPickups) do
-			local posX,posY,posZ = table.unpack(GetEntityCoords(PlayerPedId(), true))
-			if DistanceBetweenCoords(posX, posY, posZ, pickupInfo.x, pickupInfo.y, pickupInfo.z) > 300.0 then
-				TriggerServerEvent("removePickup", pickupInfo, "pickup too far, deleting\n")
-				Citizen.Trace("pickup too far, deleting: " .. table.tostring(pickupInfo))
-				table.remove(localPickups, i)
-				if pickupInfo.pickupItem ~= nil then
-					localFood = localFood - 1
-				else
-					localWeapons = localWeapons - 1
+			if pickupInfo then
+				local posX,posY,posZ = table.unpack(GetEntityCoords(PlayerPedId(), true))
+				if DistanceBetweenCoords(posX, posY, posZ, pickupInfo.x, pickupInfo.y, pickupInfo.z) > 300.0 then
+					TriggerServerEvent("removePickup", pickupInfo, "pickup too far, deleting\n")
+					Citizen.Trace("pickup too far, deleting: " .. table.tostring(pickupInfo))
+					table.remove(localPickups, i)
+					if pickupInfo.pickupItem ~= nil then
+						localFood = localFood - 1
+					else
+						localWeapons = localWeapons - 1
+					end
 				end
 			end
 		end


### PR DESCRIPTION
User in FiveM support (Cody196) noted that he was crashing (deref of nil pointer), with the log showing:

> [   2428734] 16712242 Weapon PICKUP_HEALTH_STANDARD Spawned!Removed pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickuppickup too far, deleting: {weapon="PICKUP_WEAPON_CARBINERIFLE_MK2",spawned=false,y=4484.8200683594,z=30.546875,ownerName="Cody196",x=2370.2985839844,owner=1,chance=44}Removed pickup16712244 Weapon PICKUP_WEAPON_CARBINERIFLE_MK2 Spawned!16712245 Weapon PICKUP_WEAPON_SMOKEGRENADE Spawned!16712246 Item Purified Water Spawned!16712247 Item Twinkie Spawned!16712248 Item Steak Spawned!16712249 Item Fresh Apple Spawned!16712250 Weapon PICKUP_WEAPON_NIGHTSTICK Spawned!16712252 Weapon PICKUP_HEALTH_STANDARD Spawned!Removed pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickup16712254 Weapon PICKUP_WEAPON_CARBINERIFLE_MK2 Spawned!16712255 Weapon PICKUP_WEAPON_SMOKEGRENADE Spawned!16712256 Item Purified Water Spawned!16712257 Item Twinkie Spawned!16712258 Item Steak Spawned!16712259 Item Fresh Apple Spawned!16712262 Weapon PICKUP_HEALTH_STANDARD Spawned!Removed pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickup16712264 Weapon PICKUP_WEAPON_CARBINERIFLE_MK2 Spawned!16712265 Weapon PICKUP_WEAPON_SMOKEGRENADE Spawned!16712266 Item Purified Water Spawned!16712267 Item Steak Spawned!16712268 Item Fresh Apple Spawned!pickup too far, deleting: {spawned=false,owner=1,y=4345.9775390625,z=45.5703125,ownerName="Cody196",x=2669.6481933594,pickupItemCount=1.0,pickupItem=6}16712270 Weapon PICKUP_HEALTH_STANDARD Spawned!Removed pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickupRemoved pickup16712271 Item Beef Spawned!Removed pickup16712273 Weapon PICKUP_WEAPON_CARBINERIFLE_MK2 Spawned!16712274 Weapon PICKUP_WEAPON_SMOKEGRENADE Spawned!16712275 Item Milk Bottle Spawned!16712276 Item Purified Water Spawned!16712277 Item Steak Spawned!16712278 Item Fresh Apple Spawned!pickup too far, deleting:

Due to the very last "deleting: " not showing the itemInfo, I believe that it may have been attempting to remove an item that does not exist.

This should ensure that the item actually exists before attempting to delete it.